### PR TITLE
优化相似性矩阵计算速度

### DIFF
--- a/itemcf.py
+++ b/itemcf.py
@@ -10,6 +10,7 @@ import math
 import os
 from operator import itemgetter
 
+from collections import defaultdict
 
 random.seed(0)
 
@@ -87,11 +88,10 @@ class ItemBasedCF(object):
 
         for user, movies in self.trainset.items():
             for m1 in movies:
+                itemsim_mat.setdefault(m1, defaultdict(int))
                 for m2 in movies:
                     if m1 == m2:
                         continue
-                    itemsim_mat.setdefault(m1, {})
-                    itemsim_mat[m1].setdefault(m2, 0)
                     itemsim_mat[m1][m2] += 1
 
         print('build co-rated users matrix succ', file=sys.stderr)

--- a/usercf.py
+++ b/usercf.py
@@ -10,6 +10,7 @@ import math
 import os
 from operator import itemgetter
 
+from collections import defaultdict
 
 random.seed(0)
 
@@ -93,11 +94,10 @@ class UserBasedCF(object):
 
         for movie, users in movie2users.items():
             for u in users:
+                usersim_mat.setdefault(u, defaultdict(int))
                 for v in users:
                     if u == v:
                         continue
-                    usersim_mat.setdefault(u, {})
-                    usersim_mat[u].setdefault(v, 0)
                     usersim_mat[u][v] += 1
         print ('build user co-rated movies matrix succ', file=sys.stderr)
 


### PR DESCRIPTION
改变相似性矩阵的初始化位置，能大幅缩短计算时间 。